### PR TITLE
feat: onBeforeMenuOpen event 

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,35 @@ Example:
   };
 ````
 
+### onBeforeMenuOpen (v0.0.14)
+
+The `onBeforeMenuOpen` event can be used to cancel the menu from opening and allow to modify the menu items that will be display by the current event.
+
+The `open()` callback is used to continue the context menu event and can be injected with the new modified `IShContextMenuItem` items array. (optional. if items array is not provided the original array defined by `[sh-context]` will be used.)
+
+````html
+<div (onBeforeMenuOpen)="onBefore($event)" [sh-context]="items" [sh-data-context]="dataCtxOne">
+  Click Me !
+</div>
+````
+
+component:
+
+````typescript
+onBefore = (event: BeforeMenuEvent) => {
+    event.open([new items]);
+  };
+````
+
+`BeforeMenuEvent` interface:
+````typescript
+interface BeforeMenuEvent {
+  event: MouseEvent;
+  items: IShContextMenuItem[];
+  open(items?: IShContextMenuItem[]): void;
+}
+````
+
 ### Options Object (v0.0.10)
 
 ````html

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 ### 0.0.14 (future version)
 
+onBeforeMenuOpen event [#47d4a19](https://github.com/msarsha/ng2-right-click-menu/pull/27/commits/47d4a19233ddc39f3b8f70330cf991a91faf2a06)
+
 
 ### 0.0.13 (current version)
 

--- a/index.ts
+++ b/index.ts
@@ -1,2 +1,2 @@
 export { ShContextMenuModule } from './src/sh-context-menu.module';
-export { IShContextMenuItem, IShContextOptions } from './src/sh-context-menu.models';
+export { IShContextMenuItem, IShContextOptions, BeforeMenuEvent } from './src/sh-context-menu.models';

--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,2 @@
 export { ShContextMenuModule } from './src/sh-context-menu.module';
-export { IShContextMenuItem } from './src/sh-context-item';
-export { IShContextOptions } from './src/sh-context-options';
+export { IShContextMenuItem, IShContextOptions } from './src/sh-context-menu.models';

--- a/src/sh-context-default-options.ts
+++ b/src/sh-context-default-options.ts
@@ -1,6 +1,0 @@
-import { IShContextOptions } from './sh-context-options';
-
-export const ShContextDefaultOptions: IShContextOptions = {
-  rtl: false,
-  theme:'light'
-};

--- a/src/sh-context-menu.component.ts
+++ b/src/sh-context-menu.component.ts
@@ -1,6 +1,6 @@
 import { ShContextService } from './sh-context-service';
 import { IShContextOptions } from './sh-context-options';
-import { Component, Input, Output, EventEmitter, ViewEncapsulation, OnInit, ElementRef, AfterViewInit, ViewChild, AfterContentInit } from "@angular/core";
+import { Component, Input, Output, EventEmitter, OnInit, ElementRef, ViewChild, AfterContentInit } from "@angular/core";
 
 import { IShContextMenuItem } from "./sh-context-item";
 

--- a/src/sh-context-menu.component.ts
+++ b/src/sh-context-menu.component.ts
@@ -1,8 +1,6 @@
 import { ShContextService } from './sh-context-service';
-import { IShContextOptions } from './sh-context-options';
 import { Component, Input, Output, EventEmitter, OnInit, ElementRef, ViewChild, AfterContentInit } from "@angular/core";
-
-import { IShContextMenuItem } from "./sh-context-item";
+import {IShContextMenuItem, IShContextOptions} from "./sh-context-menu.models";
 
 export interface ShContextPosition {
   top: number;

--- a/src/sh-context-menu.directive.ts
+++ b/src/sh-context-menu.directive.ts
@@ -5,9 +5,8 @@ import {
 } from "@angular/core";
 
 import {ShContextOverlayComponent} from './sh-context-overlay.component';
-import {IShContextMenuItem} from "./sh-context-item";
-import {ShContextMenuComponent, ShContextPosition} from "./sh-context-menu.component";
-import {IShContextOptions} from './sh-context-options';
+import {ShContextMenuComponent} from "./sh-context-menu.component";
+import {IShContextMenuItem, IShContextOptions} from "./sh-context-menu.models";
 
 @Directive({
   selector: '[sh-context]'
@@ -21,7 +20,6 @@ export class ShContextMenuDirective {
 
   ctxComponent: ComponentRef<ShContextMenuComponent>;
   overlayComponent: ComponentRef<ShContextOverlayComponent>;
-  modifiedMenuItems: IShContextMenuItem[];
 
   constructor(private viewRef: ViewContainerRef,
               private resolver: ComponentFactoryResolver,

--- a/src/sh-context-menu.directive.ts
+++ b/src/sh-context-menu.directive.ts
@@ -6,7 +6,7 @@ import {
 
 import {ShContextOverlayComponent} from './sh-context-overlay.component';
 import {ShContextMenuComponent} from "./sh-context-menu.component";
-import {IShContextMenuItem, IShContextOptions} from "./sh-context-menu.models";
+import {BeforeMenuEvent, IShContextMenuItem, IShContextOptions} from "./sh-context-menu.models";
 
 @Directive({
   selector: '[sh-context]'
@@ -16,7 +16,7 @@ export class ShContextMenuDirective {
   @Input('sh-data-context') dataContext: any;
   @Input('sh-options') options: IShContextOptions;
 
-  @Output('onBeforeMenuOpen') onBeforeMenuOpen = new EventEmitter();
+  @Output('onBeforeMenuOpen') onBeforeMenuOpen = new EventEmitter<BeforeMenuEvent>();
 
   ctxComponent: ComponentRef<ShContextMenuComponent>;
   overlayComponent: ComponentRef<ShContextOverlayComponent>;

--- a/src/sh-context-menu.models.ts
+++ b/src/sh-context-menu.models.ts
@@ -1,6 +1,6 @@
 export const ShContextDefaultOptions: IShContextOptions = {
   rtl: false,
-  theme:'light'
+  theme: 'light'
 };
 
 export interface IShContextMenuItem {
@@ -12,10 +12,16 @@ export interface IShContextMenuItem {
   disabled?(context: any): boolean;
   subMenu?: boolean;
   subMenuItems?: IShContextMenuItem[];
-  data?:any;
+  data?: any;
 }
 
 export interface IShContextOptions {
   rtl?: boolean;
   theme?: 'light' | 'dark'
-};
+}
+
+export interface BeforeMenuEvent {
+  event: MouseEvent;
+  items: IShContextMenuItem[];
+  open(items?: IShContextMenuItem[]): void;
+}

--- a/src/sh-context-menu.models.ts
+++ b/src/sh-context-menu.models.ts
@@ -1,3 +1,8 @@
+export const ShContextDefaultOptions: IShContextOptions = {
+  rtl: false,
+  theme:'light'
+};
+
 export interface IShContextMenuItem {
   label?: string;
   id?: string;
@@ -9,3 +14,8 @@ export interface IShContextMenuItem {
   subMenuItems?: IShContextMenuItem[];
   data?:any;
 }
+
+export interface IShContextOptions {
+  rtl?: boolean;
+  theme?: 'light' | 'dark'
+};

--- a/src/sh-context-options.ts
+++ b/src/sh-context-options.ts
@@ -1,6 +1,0 @@
-﻿//pr test
-
-export interface IShContextOptions {
-  rtl?: boolean;
-  theme?: 'light' | 'dark'
-};

--- a/src/sh-context-service.ts
+++ b/src/sh-context-service.ts
@@ -1,7 +1,6 @@
 import { Injectable, NgModule } from '@angular/core';
+import {IShContextOptions, ShContextDefaultOptions} from "./sh-context-menu.models";
 
-import { ShContextDefaultOptions } from './sh-context-default-options';
-import { IShContextOptions } from './sh-context-options';
 
 @Injectable()
 export class ShContextService {

--- a/src/sh-context-sub-menu.directive.ts
+++ b/src/sh-context-sub-menu.directive.ts
@@ -1,9 +1,8 @@
-import { IShContextOptions } from './sh-context-options';
 import { Directive, Output, ElementRef, EventEmitter, Input, HostListener, ViewContainerRef, ComponentFactoryResolver, ComponentRef, OnInit } from "@angular/core";
 
-import { IShContextMenuItem } from "./sh-context-item";
 import { ShContextMenuComponent, ShContextPosition } from "./sh-context-menu.component";
 import { ShContextService } from "./sh-context-service";
+import {IShContextMenuItem, IShContextOptions} from "./sh-context-menu.models";
 
 @Directive({
   selector: '[sh-context-sub-menu]'


### PR DESCRIPTION
@AlexLnz give it a try.

The `onBeforeMenuOpen` event can be used to cancel the menu from opening and allow to modify the menu items that will be display by the current event.

markup:

````html
<div (onBeforeMenuOpen)="onBefore($event)" [sh-context]="items" [sh-data-context]="dataCtxOne">
  Click Me !
</div>
````

component:

````typescript
onBefore = (event: BeforeMenuEvent) => {
    console.log(event);
    event.open([event.items[0]]);
  };
````

`BeforeMenuEvent` interface:
````typescript
interface BeforeMenuEvent {
  event: MouseEvent;
  items: IShContextMenuItem[];
  open(items?: IShContextMenuItem[]): void;
}
````


The `open()` callback is used to continue the context menu event and can be injected with the new modified `IShContextMenuItem` items array. (optional. if items array is not provided the original array defined by `[sh-context]` will be used.)