### PR TITLE
Preventing an empty menu from showing

### DIFF
--- a/src/sh-context-menu.directive.ts
+++ b/src/sh-context-menu.directive.ts
@@ -40,6 +40,10 @@ export class ShContextMenuDirective {
 
     this.closeMenu();
 
+    if ( this.contextMenuIsEmpty() ) {
+      return;
+    }
+
     if (this.onBeforeMenuOpen.observers.length > 0) {
       this.onBeforeMenuOpen.emit({
         event: event,
@@ -101,5 +105,9 @@ export class ShContextMenuDirective {
     this.viewRef.clear();
     if (this.overlayComponent)
       this.overlayComponent.destroy();
+  }
+
+  private contextMenuIsEmpty(): boolean {
+    return !this.menuItems || this.menuItems.length === 0;
   }
 }


### PR DESCRIPTION
Currently:
When the context menu doesn't have any menu items, it still shows as a tiny empty box.

Proposed Change:
Menu doesn't show when the array given to the input property 'sh-context' is null or empty.