### PR TITLE
Allow label to be function or string, add getLabel function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use the `[sh-data-context]` property to inject a context object of type `any`.
 
 ````typescript
   interface IShContextMenuItem {
-    label?: string; // as of version 0.0.11 this property is rendered as HTML
+    label?: (context: any) => string | string; // as of version 0.0.11 this property is rendered as HTML
     divider?: boolean;
     onClick?($event: any): void;
     visible?(context: any): boolean;
@@ -45,7 +45,7 @@ Example:
       onClick: this.clickEvent
     },
     {
-      label: 'Edit',
+      label: (context) => `Edit ${context.someVariable}`,
       onClick: this.clickEvent
     },
     {
@@ -72,7 +72,7 @@ Example:
       onClick: this.clickEvent
     },
     {
-      label: 'Hidden',
+      label: (context) => `Hide ${context.name}`,
       onClick: this.clickEvent,
       visible: ctx => {
         return ctx.One === 'One';
@@ -84,6 +84,10 @@ Example:
     console.log('clicked ', $event);
   };
 ````
+
+### Passing a function to the label option
+
+You can pass either a string or a function that returns a string (using the data context as a parameter) to the `label` option of menu items. Passing a function allows the label to contain dynamic content.
 
 ### onBeforeMenuOpen (v0.0.14)
 

--- a/src/sh-context-menu.component.ts
+++ b/src/sh-context-menu.component.ts
@@ -19,7 +19,7 @@ export interface ShContextPosition {
           <li *ngFor="let item of items"
             [ngClass]="{'sh-menu-item': !item.divider, 'sh-context-divider': item.divider, 'sh-menu-disabled': isItemDisabled(item), 'sh-menu-hidden': !isItemVisible(item)}"
             (click)="onClick(item)">
-              <div *ngIf="!item.divider && !item.subMenu" [sh-html]="item.label">
+              <div *ngIf="!item.divider && !item.subMenu" [sh-html]="getLabel(item)">
               </div> 
               <div *ngIf="item.subMenu"
                 [sh-context-sub-menu]="item.subMenuItems"
@@ -134,6 +134,15 @@ export class ShContextMenuComponent implements OnInit, AfterContentInit {
   ngAfterContentInit(): void {
     if (this.options.rtl)
       this.setRtlLocation();
+  }
+  
+  getLabel(item: IShContextMenuItem): string {
+    if (typeof item.label === 'string') {
+      return item.label;
+    } else if (typeof item.label === 'function') {
+      return item.label(this.dataContext);
+    }
+    return '';
   }
 
   close() {

--- a/src/sh-context-menu.directive.ts
+++ b/src/sh-context-menu.directive.ts
@@ -30,7 +30,7 @@ export class ShContextMenuDirective {
   }
 
   @HostListener('contextmenu', ['$event'])
-  onClick(event: MouseEvent) {
+  onClick(event: MouseEvent): boolean | void {
     this.options = this.ctxService.setOptions(this.options);
 
     this.closeMenu();

--- a/src/sh-context-menu.models.ts
+++ b/src/sh-context-menu.models.ts
@@ -4,7 +4,7 @@ export const ShContextDefaultOptions: IShContextOptions = {
 };
 
 export interface IShContextMenuItem {
-  label?: string;
+  label?: (context: any) => string | string;
   id?: string;
   divider?: boolean;
   onClick?($event: any): void;


### PR DESCRIPTION
https://github.com/msarsha/ng2-right-click-menu/issues/49

Allow context menu item label to be a function or a string: `(context: any) => string | string`. This allows you to use context variables inside the label. The `getLabel()` function determines whether your `label` is a string or function, and returns the appropriate value to use.

Updated README.md, changing some of the example items to use a function for their label.

Note: Also added a return type of `boolean | void` to the onClick function as I was getting a error compiling the TS without this (since the function doesn't always return a value).