### PR TITLE
Fix Type definition for PR #50

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Use the `[sh-data-context]` property to inject a context object of type `any`.
 
 ````typescript
   interface IShContextMenuItem {
-    label?: (context: any) => string | string; // as of version 0.0.11 this property is rendered as HTML
+    label?: ((context: any) => string) | string; // as of version 0.0.11 this property is rendered as HTML
     divider?: boolean;
     onClick?($event: any): void;
     visible?(context: any): boolean;

--- a/src/sh-context-menu.models.ts
+++ b/src/sh-context-menu.models.ts
@@ -4,7 +4,7 @@ export const ShContextDefaultOptions: IShContextOptions = {
 };
 
 export interface IShContextMenuItem {
-  label?: (context: any) => string | string;
+  label?: ((context: any) => string) | string;
   id?: string;
   divider?: boolean;
   onClick?($event: any): void;


### PR DESCRIPTION
Just realised that there was a mistake in my last PR. There should be parenthesis around the function part since it was being read as 'function that returns (string or string)', instead of 'a (function that returns string) or a string`. 
  