### PR TITLE
Close event for context menu

### DIFF
--- a/projects/ng2-right-click-menu/src/lib/sh-attach-menu.directive.ts
+++ b/projects/ng2-right-click-menu/src/lib/sh-attach-menu.directive.ts
@@ -25,6 +25,7 @@ export class ShAttachMenuDirective implements OnDestroy, OnInit {
 	@Input('shMenuTriggers') triggers: string[];
 	@Input('shMenuData') data: any;
 	@Output() open = new EventEmitter<ContextOpenEvent>();
+	@Output() close = new EventEmitter<ContextOpenEvent>();
 	sub: Subscription;
 
 	constructor(
@@ -75,6 +76,7 @@ export class ShAttachMenuDirective implements OnDestroy, OnInit {
 
 	ngOnDestroy(): void {
 		if (this.sub) {
+		  this.close.emit();
 			this.sub.unsubscribe();
 		}
 	}


### PR DESCRIPTION
Hello,
I added a close event to go alongside the new open event, that will emit when the context menu is removed from DOM.

I wanted the host component to change CSS class depending on if the menu was open or not. I have a work-around for now by waiting for clicks on Rx.Observable.fromEvent(), but this seemed like a more efficient way around it.

I'll admit this solution is incomplete, but hopefully it demonstrates what I was attempting.