### PR TITLE
Replace call to "remove" method to support IE11

### DIFF
--- a/projects/ng2-right-click-menu/src/lib/sh-context-menu.service.ts
+++ b/projects/ng2-right-click-menu/src/lib/sh-context-menu.service.ts
@@ -166,8 +166,8 @@ export class ShContextMenuService implements OnDestroy {
 	}
 
 	private closeCurrentOverlays() {
-		if (this.anchorElement) {
-			this.anchorElement.remove();
+		if (this.anchorElement && this.anchorElement.parentNode) {
+			this.anchorElement.parentNode.removeChild(this.anchorElement);
 		}
 
 		this.activeOverlays.forEach(o => {


### PR DESCRIPTION
I've replaced the call to the `remove` method in the `closeCurrentOverlays()` private method, as it's not currently supported by Internet Explorer ([See here](https://developer.mozilla.org/en-US/docs/Web/API/ChildNode/remove#Browser_compatibility)) and it's easily replaceable with the equivalent one-liner.